### PR TITLE
Hotfix/security and permission mgmt

### DIFF
--- a/src/main/java/it/polito/cloudresources/be/dto/users/CreateUserDTO.java
+++ b/src/main/java/it/polito/cloudresources/be/dto/users/CreateUserDTO.java
@@ -8,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.util.Set;
 
@@ -36,6 +37,7 @@ public class CreateUserDTO {
     private String email;
 
     @NotBlank(message = "Password is required")
+    @ToString.Exclude
     private String password;
 
     private String avatar;

--- a/src/main/java/it/polito/cloudresources/be/dto/users/UpdateProfileDTO.java
+++ b/src/main/java/it/polito/cloudresources/be/dto/users/UpdateProfileDTO.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 /**
  * DTO for users to update their own profile information
@@ -26,6 +27,7 @@ public class UpdateProfileDTO {
 
     private String avatar;
 
+    @ToString.Exclude
     private String password;
 
     private String sshPublicKey;

--- a/src/main/java/it/polito/cloudresources/be/dto/users/UpdateUserDTO.java
+++ b/src/main/java/it/polito/cloudresources/be/dto/users/UpdateUserDTO.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.util.Set;
 
@@ -29,6 +30,7 @@ public class UpdateUserDTO {
     @Email(message = "Invalid email format")
     private String email;
 
+    @ToString.Exclude
     private String password;
 
     private String avatar;

--- a/src/main/java/it/polito/cloudresources/be/service/MockKeycloakService.java
+++ b/src/main/java/it/polito/cloudresources/be/service/MockKeycloakService.java
@@ -199,7 +199,20 @@ public class MockKeycloakService extends KeycloakService {
         if (attributes.containsKey("roles")) {
             @SuppressWarnings("unchecked")
             List<String> roles = (List<String>) attributes.get("roles");
-            userRoles.put(userId, roles != null ? new ArrayList<>(roles) : new ArrayList<>());
+            
+            // Normalize site_admin role names to ensure consistency
+            List<String> normalizedRoles = roles.stream()
+                .map(roleName -> {
+                    if (roleName.endsWith("_site_admin")) {
+                        // Extract site name and normalize it
+                        String siteName = roleName.substring(0, roleName.length() - "_site_admin".length());
+                        return getSiteAdminRoleName(siteName);
+                    }
+                    return roleName;
+                })
+                .collect(Collectors.toList());
+            
+            userRoles.put(userId, normalizedRoles != null ? new ArrayList<>(normalizedRoles) : new ArrayList<>());
         }
 
         log.info("Updated mock user: {}", user.getUsername());


### PR DESCRIPTION
This pull request improves security and consistency in user data handling and role management. The most notable changes are the exclusion of sensitive information from object string representations and the normalization of role names, especially for site admin roles, to ensure they are handled uniformly when updating user roles.

**Security improvements:**

* Added `@ToString.Exclude` to the `password` field in `CreateUserDTO`, `UpdateProfileDTO`, and `UpdateUserDTO` to prevent passwords from being included in object string representations, reducing the risk of accidental exposure in logs or debugging output. [[1]](diffhunk://#diff-941fcb452f162d85bcaa58c52abecdc746c396a5c8eaf12f451a1d252daff1b8R40) [[2]](diffhunk://#diff-4f2e7c14433a4d0bf23f64688ece7f5ccb43451ee52db3f86700184fe7f16684R30) [[3]](diffhunk://#diff-c3f45790cec5966c8cead196c54e635a5ab06751e8d5fb17efc30866dbf06d6cR33)

**Role management consistency:**

* Normalized site admin role names in both `KeycloakService` and `MockKeycloakService` to ensure consistent naming and handling, reducing potential bugs related to role assignment and removal. [[1]](diffhunk://#diff-6b0ac5e80ea77fede40256b1f8ca7ea6c83bbd1108876e64157814f6e8e91918R270-R307) [[2]](diffhunk://#diff-b4fc43a66f471383f9625cb3039bc912d52dea709700b5d5be1ac0f06b8b39b7L202-R215)
* Updated the role update logic in `KeycloakService` to not only add new roles but also remove roles that are no longer assigned, ensuring user roles are accurately synchronized.
* Added a new `removeRoleFromUser` method in `KeycloakService` to support the removal of roles from users, improving the flexibility and correctness of role management operations.